### PR TITLE
Disable Auto Embedding for Discord

### DIFF
--- a/src/chat_commands.js
+++ b/src/chat_commands.js
@@ -62,9 +62,9 @@ const onMessage = (bot, username, message) => {
   const args = input.length > 1 ? input.slice(1) : []
   logger.log('command', `'${username}' used command '${cmd}' with args: ${args}`)
   if (cmd.startsWith('help') || cmd.startsWith('info') || cmd.startsWith('about')) {
-    bot.chat('I am a bot. My code is here: https://github.com/ChillerDragon/zillybot-mc')
+    bot.chat('I am a bot. My code is here: <https://github.com/ChillerDragon/zillybot-mc>')
   } else if (cmd.startsWith('bot')) { // !bot, !bots, !botter, !bothelp, !botinfo
-    bot.chat('[iambot] My code is here: https://github.com/ChillerDragon/zillybot-mc')
+    bot.chat('[iambot] My code is here: <https://github.com/ChillerDragon/zillybot-mc>')
   } else if (cmd === 'seed') {
     bot.chat(`the seed is: ${process.env.SEED}`)
   } else if (cmd === 'tps') {

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -15,7 +15,7 @@ const initHooks = (bot) => {
 
   bot.on('whisper', (username, message) => {
     logger.log('whisper', `${username}: ${message}`)
-    bot.chat('I am a bot. My code is here: https://github.com/ChillerDragon/zillybot-mc')
+    bot.chat('I am a bot. My code is here: <https://github.com/ChillerDragon/zillybot-mc>')
   })
 
   // bot.on('message', (message) => {


### PR DESCRIPTION
When the bot send a link in chat and it gets forwarded to the discord gateway, it creates an embed which clutters the chat.

Surrounding the link with <>, as mentioned in [this discord support page](https://support.discord.com/hc/en-us/articles/206342858--How-do-I-disable-auto-embed-) will disable the embeds from being generated automatically.