### PR TITLE
Add nix packaging

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1745688173,
+        "narHash": "sha256-fgvG1O5JvSSjeQx+ea0DJ3GfMbLPVhAQta/DqQ2y6jc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6a2957c7978b189202e03721aab901c0a9dc1e1a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1743296961,
+        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,36 @@
+{
+  description = "zillybot";
+
+  inputs = {
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable-small";
+  };
+  outputs =
+    inputs@{ self, flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      perSystem =
+        { self', pkgs, ... }:
+        let
+          buildNpmPackage = pkgs.buildNpmPackage.override { nodejs = pkgs.nodejs_22; };
+        in
+        {
+          packages = {
+            zillybot = buildNpmPackage {
+              pname = "zillybot";
+              version = toString (self.shortRev or self.dirtyShortRev or self.lastModified or "unknown");
+              src = ./.;
+              npmDepsHash = "sha256-S3389l4KDZF3A8NAK/dKgMBZcMsBsrR1cCiPVeNM++g=";
+              dontNpmBuild = true;
+              meta.mainProgram = "zillybot";
+            };
+            default = self'.packages.zillybot;
+          };
+
+          devShells.default = pkgs.mkShell {
+            packages = [ ];
+            inputsFrom = [ self'.packages.default ];
+          };
+        };
+      systems = inputs.nixpkgs.lib.systems.flakeExposed;
+    };
+}


### PR DESCRIPTION
Not sure if you need this but for me it's super convenient to just run `nix run .`
Depends on #19 and #20 because of `npmDepsHash` and problems with building iconv, idk if a workaround can be made for `npmDepsHash`.

If you're fine with this PR then I'll add a NixOS systemd module later.